### PR TITLE
fix name for spatial_dataset_service_settings; Allow tethys to startup

### DIFF
--- a/tethys_apps/base/app_base.py
+++ b/tethys_apps/base/app_base.py
@@ -7,6 +7,7 @@
 * License: BSD 2-Clause
 ********************************************************************************
 """
+import logging
 import os
 import sys
 
@@ -19,6 +20,7 @@ from tethys_apps.base.handoff import HandoffManager
 from tethys_apps.exceptions import (TethysAppSettingDoesNotExist,
                                     TethysAppSettingNotAssigned)
 
+tethys_log = logging.getLogger('tethys.app_base')
 
 class TethysAppBase(object):
     """
@@ -762,7 +764,7 @@ class TethysAppBase(object):
             engine = ps_database_setting.get_engine(as_url=as_url)
         except TethysAppSettingNotAssigned as ex:
             engine = None
-            print(ex)
+            tethys_log.warn(ex)
         return engine
 
     @classmethod

--- a/tethys_apps/models.py
+++ b/tethys_apps/models.py
@@ -79,7 +79,7 @@ class TethysApp(models.Model):
                 .select_subclasses('datasetservicesetting')
 
     @property
-    def spatial_dataset_services_settings(self):
+    def spatial_dataset_service_settings(self):
         return self.settings_set.exclude(spatialdatasetservicesetting__isnull=True) \
                 .select_subclasses('spatialdatasetservicesetting')
 
@@ -525,7 +525,7 @@ class PersistentStoreDatabaseSetting(TethysAppSetting):
                 .select_subclasses('datasetservicesetting')
 
     @property
-    def spatial_dataset_services_settings(self):
+    def spatial_dataset_service_settings(self):
         return self.settings_set.exclude(spatialdatasetservicesetting__isnull=True) \
                 .select_subclasses('spatialdatasetservicesetting')
 


### PR DESCRIPTION
1) Name errors fixed
2) Tethys won't start up if model expects persistent store that does not exist. Catch & print exception.